### PR TITLE
fix: add required width/height props to Next.js Image components

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   /* config options here */
-};
+  images: {
+    remotePatterns: [new URL('https://hlxtuikmmagosicqiomi.supabase.co/**')],
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/src/components/AlbumPostFeed.tsx
+++ b/src/components/AlbumPostFeed.tsx
@@ -124,6 +124,8 @@ export default function AlbumPostFeed({ albumId }: AlbumPostFeedProps) {
                     <Image
                       src={image.image_url}
                       alt={image.caption || 'Post image'}
+                      width={500}
+                      height={500}
                       className='w-full rounded-lg max-h-96 object-cover'
                     />
                     {image.caption && (

--- a/src/components/CreatePostForm.tsx
+++ b/src/components/CreatePostForm.tsx
@@ -256,6 +256,8 @@ export default function CreatePostForm({
                           <Image
                             src={image.preview}
                             alt={`Upload ${index + 1}`}
+                            width={500}
+                            height={500}
                             className='w-20 h-20 object-cover rounded'
                           />
                           <Button

--- a/src/components/PostFeed.tsx
+++ b/src/components/PostFeed.tsx
@@ -117,6 +117,8 @@ export default function PostFeed() {
                     <Image
                       src={image.image_url}
                       alt={image.caption || 'Post image'}
+                      width={500}
+                      height={500}
                       className='w-full rounded-lg max-h-96 object-cover'
                     />
                     {image.caption && (


### PR DESCRIPTION
## Summary
• Fixed Next.js Image component usage by adding required width and height props
• Added Supabase remote pattern configuration for image optimization
• Updated image components across AlbumPostFeed, CreatePostForm, and PostFeed

## Changes Made
• Added `width={500}` and `height={500}` props to all Image components
• Configured `remotePatterns` in next.config.ts for Supabase image domain
• Updated quote style consistency in next.config.ts

## Test Plan
- [ ] Verify images render correctly in album post feed
- [ ] Verify images render correctly in create post form preview
- [ ] Verify images render correctly in main post feed
- [ ] Test image optimization and loading performance
- [ ] Verify no console warnings about missing width/height props

🤖 Generated with [Claude Code](https://claude.ai/code)