### PR TITLE
SPE-109: Fix album details mobile responsiveness

### DIFF
--- a/src/components/AlbumPostFeed.tsx
+++ b/src/components/AlbumPostFeed.tsx
@@ -72,7 +72,7 @@ export default function AlbumPostFeed({ albumId }: AlbumPostFeedProps) {
                 Be the first to share a memory in this album.
               </p>
             </div>
-            <Button asChild>
+            <Button asChild className='w-full sm:w-auto'>
               <Link href={`/create?album=${albumId}`}>
                 <Plus className='w-4 h-4 mr-2' />
                 Add First Post
@@ -89,17 +89,17 @@ export default function AlbumPostFeed({ albumId }: AlbumPostFeedProps) {
       {posts.map((post) => (
         <Card key={post.id} className='overflow-hidden'>
           <CardHeader className='pb-3'>
-            <div className='flex items-center justify-between'>
+            <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3'>
               <div className='flex items-center space-x-3'>
-                <Avatar>
+                <Avatar className='w-10 h-10 sm:w-9 sm:h-9'>
                   <AvatarImage src={post.author.avatar_url || undefined} />
                   <AvatarFallback>
                     {post.author.full_name?.charAt(0) ||
                       post.author.email.charAt(0).toUpperCase()}
                   </AvatarFallback>
                 </Avatar>
-                <div>
-                  <p className='font-medium text-sm'>
+                <div className='min-w-0 flex-1'>
+                  <p className='font-medium text-sm truncate'>
                     {post.author.full_name || post.author.email}
                   </p>
                   <p className='text-xs text-gray-500'>
@@ -110,13 +110,13 @@ export default function AlbumPostFeed({ albumId }: AlbumPostFeedProps) {
                 </div>
               </div>
               {post.milestone_type && (
-                <Badge variant='secondary'>
+                <Badge variant='secondary' className='self-start sm:self-auto'>
                   {MILESTONE_LABELS[post.milestone_type]}
                 </Badge>
               )}
             </div>
             {post.title && (
-              <h3 className='font-semibold text-lg mt-2'>{post.title}</h3>
+              <h3 className='font-semibold text-base sm:text-lg mt-2'>{post.title}</h3>
             )}
           </CardHeader>
 

--- a/src/components/AlbumView.tsx
+++ b/src/components/AlbumView.tsx
@@ -87,54 +87,61 @@ export default function AlbumView({ albumId }: AlbumViewProps) {
     <div className='min-h-screen bg-gray-50'>
       <div className='container mx-auto px-4 py-8 max-w-4xl'>
         {/* Header */}
-        <div className='flex items-center gap-4 mb-8'>
-          <Button variant='ghost' onClick={() => router.push('/albums')}>
-            <ArrowLeft className='w-4 h-4' />
-          </Button>
-          <div className='flex-1'>
-            <div className='flex items-center gap-3 mb-2'>
-              <h1 className='text-3xl font-bold'>{album.name}</h1>
-              {album.privacy_level === AlbumPrivacyLevel.PUBLIC ? (
-                <Badge variant='secondary' className='flex items-center gap-1'>
-                  <Globe className='w-3 h-3' />
-                  Public
-                </Badge>
-              ) : (
-                <Badge variant='outline' className='flex items-center gap-1'>
-                  <Lock className='w-3 h-3' />
-                  Private
-                </Badge>
+        <div className='flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8'>
+          <div className='flex items-start gap-4'>
+            <Button variant='ghost' onClick={() => router.push('/albums')}>
+              <ArrowLeft className='w-4 h-4' />
+            </Button>
+            <div className='flex-1'>
+              <div className='flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 mb-2'>
+                <h1 className='text-2xl sm:text-3xl font-bold'>{album.name}</h1>
+                {album.privacy_level === AlbumPrivacyLevel.PUBLIC ? (
+                  <Badge variant='secondary' className='flex items-center gap-1 w-fit'>
+                    <Globe className='w-3 h-3' />
+                    Public
+                  </Badge>
+                ) : (
+                  <Badge variant='outline' className='flex items-center gap-1 w-fit'>
+                    <Lock className='w-3 h-3' />
+                    Private
+                  </Badge>
+                )}
+              </div>
+              {album.description && (
+                <p className='text-gray-600 mb-2'>{album.description}</p>
               )}
-            </div>
-            {album.description && (
-              <p className='text-gray-600 mb-2'>{album.description}</p>
-            )}
-            <div className='flex items-center gap-6 text-sm text-gray-500'>
-              <div className='flex items-center gap-1'>
-                <Users className='w-4 h-4' />
-                <span>
-                  {album.member_count}{' '}
-                  {album.member_count === 1 ? 'member' : 'members'}
-                </span>
-              </div>
-              <div className='flex items-center gap-1'>
-                <ImageIcon className='w-4 h-4' />
-                <span>{album.post_count || 0} posts</span>
-              </div>
-              <div className='flex items-center gap-1'>
-                <Calendar className='w-4 h-4' />
-                <span>
-                  Created{' '}
-                  {formatDistanceToNow(new Date(album.created_at), {
-                    addSuffix: true,
-                  })}
-                </span>
+              <div className='flex flex-wrap gap-4 sm:gap-6 text-sm text-gray-500'>
+                <div className='flex items-center gap-1'>
+                  <Users className='w-4 h-4' />
+                  <span>
+                    {album.member_count}{' '}
+                    {album.member_count === 1 ? 'member' : 'members'}
+                  </span>
+                </div>
+                <div className='flex items-center gap-1'>
+                  <ImageIcon className='w-4 h-4' />
+                  <span>{album.post_count || 0} posts</span>
+                </div>
+                <div className='flex items-center gap-1'>
+                  <Calendar className='w-4 h-4' />
+                  <span className='hidden sm:inline'>
+                    Created{' '}
+                    {formatDistanceToNow(new Date(album.created_at), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                  <span className='sm:hidden'>
+                    {formatDistanceToNow(new Date(album.created_at), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                </div>
               </div>
             </div>
           </div>
-          <div className='flex gap-2'>
+          <div className='flex flex-col sm:flex-row gap-2'>
             {permissions.canCreatePosts && (
-              <Button asChild>
+              <Button asChild className='w-full sm:w-auto'>
                 <Link href={`/create?album=${albumId}`}>
                   <Plus className='w-4 h-4 mr-2' />
                   Add Post
@@ -142,9 +149,10 @@ export default function AlbumView({ albumId }: AlbumViewProps) {
               </Button>
             )}
             {permissions.canEditAlbum && (
-              <Button variant='outline' asChild>
+              <Button variant='outline' asChild className='w-full sm:w-auto'>
                 <Link href={`/albums/${albumId}/settings`}>
-                  <Settings className='w-4 h-4' />
+                  <Settings className='w-4 h-4 mr-1 sm:mr-0' />
+                  <span className='sm:hidden ml-1'>Settings</span>
                 </Link>
               </Button>
             )}
@@ -154,10 +162,10 @@ export default function AlbumView({ albumId }: AlbumViewProps) {
         {/* Album Info Card */}
         <Card className='mb-8'>
           <CardHeader>
-            <CardTitle className='flex items-center justify-between'>
+            <CardTitle className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3'>
               <span>Album Members</span>
               {permissions.canInviteMembers && (
-                <Button size='sm' onClick={() => setInviteModalOpen(true)}>
+                <Button size='sm' onClick={() => setInviteModalOpen(true)} className='w-full sm:w-auto'>
                   <UserPlus className='w-4 h-4 mr-2' />
                   Invite Members
                 </Button>
@@ -165,14 +173,14 @@ export default function AlbumView({ albumId }: AlbumViewProps) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className='flex items-center space-x-3'>
+            <div className='flex flex-col sm:flex-row sm:items-center gap-3 sm:space-x-3'>
               {album.members && album.members.length > 0 ? (
                 <>
-                  <div className='flex -space-x-2'>
+                  <div className='flex -space-x-2 overflow-x-auto max-w-full'>
                     {album.members.slice(0, 8).map((member) => (
                       <Avatar
                         key={member.id}
-                        className='w-8 h-8 border-2 border-white'
+                        className='w-8 h-8 border-2 border-white flex-shrink-0'
                       >
                         <AvatarImage
                           src={member.user?.avatar_url || undefined}
@@ -183,7 +191,7 @@ export default function AlbumView({ albumId }: AlbumViewProps) {
                       </Avatar>
                     ))}
                     {album.members.length > 8 && (
-                      <div className='w-8 h-8 rounded-full bg-gray-200 border-2 border-white flex items-center justify-center'>
+                      <div className='w-8 h-8 rounded-full bg-gray-200 border-2 border-white flex items-center justify-center flex-shrink-0'>
                         <span className='text-xs text-gray-600'>
                           +{album.members.length - 8}
                         </span>


### PR DESCRIPTION
## Summary
This PR fixes mobile responsiveness issues in the album details page as described in Linear ticket SPE-109.

### Changes Made:
- **Album Header**: Title and privacy badge now stack vertically on mobile with responsive font sizes
- **Action Buttons**: Add Post and Settings buttons stack vertically and go full-width on mobile
- **Members Card**: Title and invite button stack vertically, avatar stack has horizontal scroll
- **Post Cards**: Author info and milestone badges stack properly on mobile
- **General**: Implemented mobile-first approach using Tailwind's responsive utilities

### Screenshots
Please test on various mobile devices to verify the improvements.

### Linear Ticket
[SPE-109: Album Details not mobile friendly](https://linear.app/spenzerino/issue/SPE-109/album-details-not-mobile-friendly)

## Test Plan
- [ ] View album details page on mobile devices (iPhone SE, standard phones)
- [ ] Check that all elements stack properly without horizontal overflow
- [ ] Verify buttons are full-width and easily tappable on mobile
- [ ] Test avatar stack horizontal scrolling
- [ ] Confirm desktop layout remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)